### PR TITLE
Remove nested provider configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,37 +7,68 @@ It provides a static web server by AWS Cloudfront and S3.
 
 ## Requirements
 
-No requirements.
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.15.5 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 3.30.0, < 4.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| archive | n/a |
-| aws | n/a |
-| template | n/a |
+| <a name="provider_archive"></a> [archive](#provider\_archive) | n/a |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 3.30.0, < 4.0 |
+| <a name="provider_template"></a> [template](#provider\_template) | n/a |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_acm"></a> [acm](#module\_acm) | terraform-aws-modules/acm/aws | ~> v3.0 |
+| <a name="module_basic_auth_as_lambda_edge"></a> [basic\_auth\_as\_lambda\_edge](#module\_basic\_auth\_as\_lambda\_edge) | terraform-aws-modules/lambda/aws | ~> v2.4.0 |
+| <a name="module_cdn"></a> [cdn](#module\_cdn) | terraform-aws-modules/cloudfront/aws | ~> 2.5.0 |
+| <a name="module_static"></a> [static](#module\_static) | terraform-aws-modules/s3-bucket/aws | ~> v2.4.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_iam_access_key.ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_access_key) | resource |
+| [aws_iam_user.ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user) | resource |
+| [aws_iam_user_policy.ci](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_user_policy) | resource |
+| [aws_route53_record.service](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/route53_record) | resource |
+| [aws_s3_bucket_object.index_html](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_bucket_object.secret_json](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_object) | resource |
+| [aws_s3_bucket_policy.origin_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_bucket_policy) | resource |
+| [archive_file.basic_auth_function](https://registry.terraform.io/providers/hashicorp/archive/latest/docs/data-sources/file) | data source |
+| [aws_iam_policy_document.cf_access](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
+| [aws_route53_zone.selected](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/route53_zone) | data source |
+| [template_file.basic_auth_function](https://registry.terraform.io/providers/hashicorp/template/latest/docs/data-sources/file) | data source |
 
 ## Inputs
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| basic\_auth\_credentials | Credentials for Basic Authentication. Pass a map composed of 'user' and 'password'. | `object({ username = string, password = string })` | `null` | no |
-| domain | n/a | `string` | `null` | no |
-| enable\_log | n/a | `bool` | `false` | no |
-| lambda\_role\_permissions\_boundary | ARN of IAM policy that scopes aws\_iam\_role access for the lambda | `string` | `null` | no |
-| log\_bucket\_domain | n/a | `string` | `null` | no |
-| mininum\_protocol\_version | n/a | `string` | `"TLSv1"` | no |
-| name\_prefix | Prefix of almost resource names. | `string` | n/a | yes |
-| name\_suffix | Suffix of almost resource names. Ex) some random string | `string` | n/a | yes |
-| price\_class | n/a | `string` | `"PriceClass_100"` | no |
-| route53\_zone\_name | n/a | `string` | `null` | no |
-| tags | n/a | `map(string)` | `{}` | no |
+| <a name="input_basic_auth_credentials"></a> [basic\_auth\_credentials](#input\_basic\_auth\_credentials) | Credentials for Basic Authentication. Pass a map composed of 'user' and 'password'. | `object({ username = string, password = string })` | `null` | no |
+| <a name="input_domain"></a> [domain](#input\_domain) | n/a | `string` | `null` | no |
+| <a name="input_enable_log"></a> [enable\_log](#input\_enable\_log) | n/a | `bool` | `false` | no |
+| <a name="input_lambda_role_permissions_boundary"></a> [lambda\_role\_permissions\_boundary](#input\_lambda\_role\_permissions\_boundary) | ARN of IAM policy that scopes aws\_iam\_role access for the lambda | `string` | `null` | no |
+| <a name="input_log_bucket_domain"></a> [log\_bucket\_domain](#input\_log\_bucket\_domain) | n/a | `string` | `null` | no |
+| <a name="input_log_prefix"></a> [log\_prefix](#input\_log\_prefix) | n/a | `string` | `""` | no |
+| <a name="input_mininum_protocol_version"></a> [mininum\_protocol\_version](#input\_mininum\_protocol\_version) | n/a | `string` | `"TLSv1"` | no |
+| <a name="input_name_prefix"></a> [name\_prefix](#input\_name\_prefix) | Prefix of almost resource names. | `string` | n/a | yes |
+| <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | Suffix of almost resource names. Ex) some random string | `string` | n/a | yes |
+| <a name="input_price_class"></a> [price\_class](#input\_price\_class) | n/a | `string` | `"PriceClass_100"` | no |
+| <a name="input_route53_zone_name"></a> [route53\_zone\_name](#input\_route53\_zone\_name) | n/a | `string` | `null` | no |
+| <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `{}` | no |
 
 ## Outputs
 
 | Name | Description |
 |------|-------------|
-| s3\_cdn\_bucket | n/a |
-| s3\_cdn\_bucket\_domain\_name | n/a |
-| s3\_cdn\_cf\_domain\_name | n/a |
-| s3\_cdn\_custom\_domain | n/a |
+| <a name="output_s3_cdn_bucket"></a> [s3\_cdn\_bucket](#output\_s3\_cdn\_bucket) | n/a |
+| <a name="output_s3_cdn_bucket_domain_name"></a> [s3\_cdn\_bucket\_domain\_name](#output\_s3\_cdn\_bucket\_domain\_name) | n/a |
+| <a name="output_s3_cdn_cf_domain_name"></a> [s3\_cdn\_cf\_domain\_name](#output\_s3\_cdn\_cf\_domain\_name) | n/a |
+| <a name="output_s3_cdn_custom_domain"></a> [s3\_cdn\_custom\_domain](#output\_s3\_cdn\_custom\_domain) | n/a |
+| <a name="output_s3_cdn_iam_user_access_key"></a> [s3\_cdn\_iam\_user\_access\_key](#output\_s3\_cdn\_iam\_user\_access\_key) | n/a |
+| <a name="output_s3_cdn_iam_user_encrypted_secret_key"></a> [s3\_cdn\_iam\_user\_encrypted\_secret\_key](#output\_s3\_cdn\_iam\_user\_encrypted\_secret\_key) | n/a |

--- a/example/main.tf
+++ b/example/main.tf
@@ -1,3 +1,7 @@
+provider "aws" {
+  alias = "use1"
+  region = "us-east-1"
+}
 
 locals {
   name_prefix = "test-cdn"
@@ -36,4 +40,8 @@ module "cdn" {
 
   log_bucket_domain = module.log.s3_bucket_bucket_domain_name
   log_prefix = "cdn"
+
+  providers = {
+    aws.global_region = aws.use1
+  }
 }

--- a/example/outputs.tf
+++ b/example/outputs.tf
@@ -1,16 +1,7 @@
 output "output" {
   description = "Resource informations"
   value       = <<EOT
-# Belows are used by lambda
-export STATIC_S3_BUCKET=${module.cdn.s3_cdn_bucket}
-export STATIC_S3_BUCKET_DOMAIN_NAME=${module.cdn.s3_cdn_bucket_domain_name}
-export CLOUDFRONT_DOMAIN=${module.cdn.s3_cdn_cf_domain_name}
-export CUSTOM_DOMAIN=${module.cdn.s3_cdn_custom_domain}
-export AWS_ACCESS_KEY_ID=${module.cdn.s3_cdn_iam_user_access_key}
-export AWS_SECRET_ACCESS_KEY=<decrypt below encrypted secret key>
-
------------- Encrypted secret key ------------
-${module.cdn.s3_cdn_iam_user_encrypted_secret_key}
-
+# To check your resources,
+$ terraform state list
 EOT
 }

--- a/main.tf
+++ b/main.tf
@@ -1,18 +1,3 @@
-provider "aws" {
-  alias = "us-east-1"
-  region = "us-east-1"
-}
-
-terraform {
-  required_version = ">= 0.14.7"
-  required_providers {
-    aws = {
-      version = ">= 3.30.0, < 4.0"
-      source = "hashicorp/aws"
-    }
-  }
-}
-
 ##############################
 # S3 for static assets
 
@@ -120,7 +105,7 @@ module "basic_auth_as_lambda_edge" {
   tags                              = var.tags
 
   providers = {
-    aws = aws.us-east-1
+    aws = aws.global_region
   }
 }
 
@@ -211,7 +196,7 @@ module "acm" {
   tags                      = var.tags
 
   providers = {
-    aws = aws.us-east-1
+    aws = aws.global_region
   }
 }
 

--- a/versions.tf
+++ b/versions.tf
@@ -1,0 +1,10 @@
+terraform {
+  required_version = ">= 0.15.5"
+  required_providers {
+    aws = {
+      source = "hashicorp/aws"
+      version = ">= 3.30.0, < 4.0"
+      configuration_aliases = [aws.global_region]
+    }
+  }
+}


### PR DESCRIPTION
- module 정의에 count를 사용하면 아래와 같은 에러가 발생하였었다.

```
Error: Module does not support count

  on main.tf line 26, in module "cdn":
  26:   count = 1

Module "cdn" cannot be used with count because it contains a nested provider
configuration for "aws.us-east-1", at ../main.tf:1,10-15.

This module can be made compatible with count by changing it to receive all of
its provider configurations from the calling module, by using the "providers"
argument in the calling module block.
```

- 모듈에서 provider 설정 삭제 후 `configuration_aliases` 설정을 추가, global_region provider를 모듈 외부에서
  전달해 주는 방식으로 변경하여 count 사용을 가능하게 개선.
- `configuration_aliases` 설정을 추가할 수 있게 terraform 최소 요구 버전을 높임.