### PR TITLE
chore: add static_bucket_name for usage of existing bucket

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,7 @@ It provides a static web server by AWS Cloudfront and S3.
 | <a name="input_name_suffix"></a> [name\_suffix](#input\_name\_suffix) | Suffix of almost resource names. Ex) some random string | `string` | n/a | yes |
 | <a name="input_price_class"></a> [price\_class](#input\_price\_class) | n/a | `string` | `"PriceClass_100"` | no |
 | <a name="input_route53_zone_name"></a> [route53\_zone\_name](#input\_route53\_zone\_name) | n/a | `string` | `null` | no |
+| <a name="input_static_bucket_name"></a> [static\_bucket\_name](#input\_static\_bucket\_name) | S3 Bucket name for static assets. It is mainly used when you want to reuse an existing bucket by importing it. | `string` | `null` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | n/a | `map(string)` | `{}` | no |
 
 ## Outputs

--- a/main.tf
+++ b/main.tf
@@ -5,7 +5,7 @@ module "static" {
   source  = "terraform-aws-modules/s3-bucket/aws"
   version = "~> v2.4.0"
 
-  bucket  = "${var.name_prefix}-static-${var.name_suffix}"
+  bucket  = var.static_bucket_name != null ? var.static_bucket_name : "${var.name_prefix}-static-${var.name_suffix}"
   acl     = "private"
 
   block_public_acls       = true

--- a/variables.tf
+++ b/variables.tf
@@ -8,6 +8,12 @@ variable "name_suffix" {
   description = "Suffix of almost resource names. Ex) some random string"
 }
 
+variable "static_bucket_name" {
+  type        = string
+  description = "S3 Bucket name for static assets. It is mainly used when you want to reuse an existing bucket by importing it."
+  default     = null
+}
+
 variable "enable_log" {
   type    = bool
   default = false


### PR DESCRIPTION
- S3 버킷의 경우 이름이 달라지면 삭제 후 다시 만들어야한다.
- 버킷에 이미 많은 데이터가 있어 삭제가 어려울 경우, 기존 버킷을 `terraform import` 를 통해 사용할 수 있게 `static_bucket_name` variable을 추가함.